### PR TITLE
Inject ads into bin outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ All derivations are equal, but some are more equal than others. With the new **n
 
 * **Premium build environment:** With **nixpkgs gold**, you gain access to `pkgs.premenv`, a build environment for only the finest derivations. Use it with your license key to reap the benefits of premium derivations.
 
-![image](https://github.com/user-attachments/assets/08f88e0b-e847-4afa-9cc0-f29079d30122)
+  ![image](https://github.com/user-attachments/assets/08f88e0b-e847-4afa-9cc0-f29079d30122)
 
 * **Affordable and accessible:** If you can't afford a **nixpkgs gold** license, fear not! Our `pkgs.premenv` build environment can be trialed for free thanks to our generous sponsors.
 
-![image](https://github.com/user-attachments/assets/5423c53f-ce1e-4788-9c4f-ee7ee878f140)
+  ![image](https://github.com/user-attachments/assets/5423c53f-ce1e-4788-9c4f-ee7ee878f140)
 
 * **Adaptable and extensible:** Use `lib` to configure the behavior of premium derivations and keep them out of the hands of common, vulgar nix stores.
 
-![image](https://github.com/user-attachments/assets/09160fe1-7efa-4e02-b55e-383dedba0b7d)
+  ![image](https://github.com/user-attachments/assets/09160fe1-7efa-4e02-b55e-383dedba0b7d)

--- a/ads.txt
+++ b/ads.txt
@@ -30,3 +30,10 @@ Open your Windows with NixOS-WSL
 Is there data on your computer? Fix that with Impermanence
 STEERING COMMITTEE IS WATCHING YOU
 Do your duty -- review a PR >>> https://github.com/NixOS/nixpkgs/pulls <<<
+Buy now, and we'll throw in a second copy of nixpkgs absolutely free!
+Nix Pills: If your instantiation lasts for more than four hours, contact your package maintainer
+Sponsored by NixDonalds: I'm Buildin' It
+Tired of reality? Try hallucinating! It's free and enjoyable in your own home
+Have you ever been far even as decided to use even go want to do look more like?
+Can't solve your build error? Me neither, good luck with that
+For a good time call lib.fixedPoints.fix

--- a/flake.nix
+++ b/flake.nix
@@ -28,12 +28,19 @@
             premenv = pkgs.callPackage ./premenv.nix { };
           };
 
-          checks = {
-            withoutLicense = pkgs.hello.override { stdenv = self'.packages.premenv; };
-            withLicense = self'.checks.withoutLicense.overrideAttrs {
-              goldLicense = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
+          checks =
+            let
+              goldstd = drv: drv.override { stdenv = self'.packages.premenv; };
+            in
+            {
+              withoutLicense = (goldstd pkgs.hello).overrideAttrs (prevAttrs: {
+                name = "trial-${prevAttrs.pname}-${prevAttrs.version}";
+              });
+              withLicense = (goldstd pkgs.hello).overrideAttrs (prevAttrs: {
+                name = "licensed-${prevAttrs.pname}-${prevAttrs.version}";
+                goldLicense = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
+              });
             };
-          };
         };
       flake = {
         lib = import ./lib.nix;

--- a/premenv.nix
+++ b/premenv.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  makeWrapper,
   ...
 }:
 stdenv.override (stdenvPrev: {
@@ -31,6 +32,8 @@ stdenv.override (stdenvPrev: {
         premDrv = drv.overrideAttrs (
           finalAttrs: prevAttrs: {
             premium = true;
+
+            nativeBuildInputs = (prevAttrs.nativeBuildInputs or [ ]) ++ [ makeWrapper ];
 
             # use the gold linker, obviously
             NIX_CFLAGS_LINK = toString (mkDrvArgs.NIX_CFLAGS_LINK or "") + " -fuse-ld=gold";
@@ -72,7 +75,14 @@ stdenv.override (stdenvPrev: {
             postBuildAds = adBreak;
             goldPostPhase = ''
               if [[ -z "$goldLicense" ]]; then
-                printf "Did you enjoy your build environment? Buy a \033[33;1mnixpkgs gold\033[0m license!"
+                find -L "$out/bin" -type f -executable | while read binfile; do
+                  wrapProgram "$binfile" \
+                    --run 'NIXPKGS_GOLD_AD=$(shuf -n 1 ${./ads.txt})' \
+                    --run "printf 'This program was built with \033[33;1mnixpkgs gold\033[0m free trial\n' >&2" \
+                    --run 'echo "|AD|''${NIXPKGS_GOLD_AD%'"'"'\n'"'"'}|AD|" | sed "s/nixpkgs gold/\x1b[33;1mnixpkgs gold\x1b[0m/g" >&2' \
+                    --run 'sleep 3'
+                done
+                printf "Did you enjoy your build environment? Buy a \033[33;1mnixpkgs gold\033[0m license!\n"
                 sleep 3
               else
                 printf "Thank you for using the \033[33;1mnixpkgs gold\033[0m premium build environment!\n"


### PR DESCRIPTION
This will give our sponsors some extra exposure as well as incentivize trial users to upgrade.

The ad display time is currently `sleep 3`, but this could be configured differently based on usability research. Ideally, we would show ads after a program terminates, so it remains visible even if there is a lot of output, but `wrapProgram` uses `exec` so we have to show them up front with a `sleep` delay.