### PR TITLE
premenv: require EULA acceptance

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,14 @@
           ...
         }:
         {
+          # Useful overlay for nixpkgs that doesn't work for nixpkgs-gold because of the EULA.
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [
+              self.overlays.gold
+            ];
+          };
+
           # nixpkgs attribute automatically accepting the EULA. Only used for checks.
           _module.args.pkgsEulaAccepted = import inputs.nixpkgs {
             inherit system;
@@ -39,13 +47,30 @@
 
           checks =
             let
-              goldstd = drv: drv.override { stdenv = pkgsEulaAccepted.premenv; };
+              goldNoEula = attr: pkgs.${attr}.override { stdenv = pkgs.premenv; };
+              goldStd = attr: pkgsEulaAccepted.${attr}.override { stdenv = pkgsEulaAccepted.premenv; };
             in
             {
-              withoutLicense = (goldstd pkgsEulaAccepted.hello).overrideAttrs (prevAttrs: {
+              noEula = pkgs.stdenvNoCC.mkDerivation {
+                name = "no-eula";
+                inherit (builtins.tryEval (goldNoEula "hello")) success value;
+                phases = [ "checkPhase" "installPhase" ];
+                doCheck = true;
+                checkPhase = ''
+                  if [ -n "$success" ] || [ -n "$value" ]; then
+                    echo "Evaluating no EULA accepted derivation should have thrown." >&2
+                    echo "Instead we got ($success, $value)" >&2
+                    exit 1
+                  fi
+                '';
+                installPhase = ''
+                  ln -s /dev/null $out
+                '';
+              };
+              withoutLicense = (goldStd "hello").overrideAttrs (prevAttrs: {
                 name = "trial-${prevAttrs.pname}-${prevAttrs.version}";
               });
-              withLicense = (goldstd pkgsEulaAccepted.hello).overrideAttrs (prevAttrs: {
+              withLicense = (goldStd "hello").overrideAttrs (prevAttrs: {
                 name = "licensed-${prevAttrs.pname}-${prevAttrs.version}";
                 goldLicense = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
               });

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,6 @@
 final: prev: {
   premenv = prev.callPackage ./premenv.nix { };
+  lib = prev.lib // {
+    gold = import ./lib.nix;
+  };
 }

--- a/premenv.nix
+++ b/premenv.nix
@@ -1,8 +1,18 @@
 {
+  lib,
+  config,
   stdenv,
   makeWrapper,
   ...
 }:
+
+assert lib.assertMsg (config.gold.acceptEula or false) ''
+  You must accept the ${lib.gold.nixpkgsGold} EULA to continue. Read the terms
+  below, and set `gold.acceptEula` in your nixpkgs configuration once you agree:
+
+  ${builtins.readFile ./LICENSE}
+'';
+
 stdenv.override (stdenvPrev: {
   name = "premenv";
   extraAttrs = {


### PR DESCRIPTION
We should show the user a EULA like many other derivations in nixpkgs, especially those distributed by Google and Broadcom.

Closes #2